### PR TITLE
[THNK-51] Setup 404 page customizer option to load chosen block areas

### DIFF
--- a/wp-content/themes/thinkery/404.php
+++ b/wp-content/themes/thinkery/404.php
@@ -17,15 +17,20 @@ remove_action( 'genesis_loop', 'genesis_do_loop' );
  */
 add_filter( 'genesis_pre_get_option_site_layout', '__genesis_return_full_width_content' );
 
-/**
- * Remove custom hero header
- */
-remove_action( 'genesis_before_content_sidebar_wrap', 'thinkery_hero_header', 1 );
 
-/**
- * Output a 404 "Not Found" heading.
- */
-add_action( 'genesis_loop', 'genesis_404_heading' );
+
+// Get chosen 404 Block Area from Customizer > 404 Page
+$block_area = get_theme_mod( '404_page_block_area' );
+
+// Load our custom block area if set, otherwise print out fallback 404 content
+if ( ! empty( $block_area ) ) {
+	add_action( 'genesis_after_content', 'thinkery_404_block_area' );
+	add_filter( 'body_class', 'thinkery_programs_body_class' );
+} else {
+	add_action( 'genesis_loop', 'genesis_404_heading' );
+	add_action( 'genesis_loop', 'genesis_404_content' );
+}
+
 /**
  * Output a 404 "Not Found" heading.
  *
@@ -57,16 +62,6 @@ function genesis_404_heading() {
 		]
 	);
 
-}
-
-// Get chosen 404 Block Area from Customizer > 404 Page
-$block_area = get_theme_mod( '404_page_block_area' );
-
-// Load our custom block area if set, otherwise print out fallback 404 content
-if ( ! empty( $block_area ) ) {
-	add_action( 'genesis_after_content', 'thinkery_404_block_area' );
-} else {
-	add_action( 'genesis_loop', 'genesis_404_content' );
 }
 
 /**
@@ -113,5 +108,14 @@ function thinkery_404_block_area() {
 	$block_area = get_theme_mod( '404_page_block_area', true );
 	\Thinkery\block_area()->show( $block_area );
 }
+
+/**
+ * Add custom body class to the head
+ */
+function thinkery_404_body_class( $classes ) {
+	$classes[] = 'genesis-title-hidden';
+	return $classes;
+}
+
 
 genesis();

--- a/wp-content/themes/thinkery/404.php
+++ b/wp-content/themes/thinkery/404.php
@@ -1,0 +1,117 @@
+<?php
+ /**
+ * 404 Page
+ *
+ * The template for displaying 404 pages (not found)
+ *
+ * @link https://codex.wordpress.org/Creating_an_Error_404_Page
+ */
+
+/**
+ * Remove default loop.
+ */
+remove_action( 'genesis_loop', 'genesis_do_loop' );
+
+/**
+ * Get Full Page Width layout (no sidebar)
+ */
+add_filter( 'genesis_pre_get_option_site_layout', '__genesis_return_full_width_content' );
+
+/**
+ * Remove custom hero header
+ */
+remove_action( 'genesis_before_content_sidebar_wrap', 'thinkery_hero_header', 1 );
+
+/**
+ * Output a 404 "Not Found" heading.
+ */
+add_action( 'genesis_loop', 'genesis_404_heading' );
+/**
+ * Output a 404 "Not Found" heading.
+ *
+ * Based on original Genesis 404.php.
+ * @since 1.6
+ */
+function genesis_404_heading() {
+
+	genesis_markup(
+		[
+			'open'    => '<article class="entry">',
+			'context' => 'entry-404',
+		]
+	);
+
+	genesis_markup(
+		[
+			'open'    => '<h1 %s>',
+			'close'   => '</h1>',
+			'content' => apply_filters( 'genesis_404_entry_title', __( 'We couldn\'t find your page', 'thinkery' ) ),
+			'context' => 'entry-title',
+		]
+	);
+
+	genesis_markup(
+		[
+			'close'   => '</article>',
+			'context' => 'entry-404',
+		]
+	);
+
+}
+
+// Get chosen 404 Block Area from Customizer > 404 Page
+$block_area = get_theme_mod( '404_page_block_area' );
+
+// Load our custom block area if set, otherwise print out fallback 404 content
+if ( ! empty( $block_area ) ) {
+	add_action( 'genesis_after_content', 'thinkery_404_block_area' );
+} else {
+	add_action( 'genesis_loop', 'genesis_404_content' );
+}
+
+/**
+ * Output fallback 404 content.
+ */
+function genesis_404_content() {
+
+	$genesis_404_content = sprintf(
+		/* translators: %s: URL for current website. */
+
+		__( 'The page you were looking for does not exist or is no longer available. You can either return to the <a href="%s">homepage</a> or use the search box in the upper right corner of any page to find the content you were looking for.', 'thinkery' ),
+		esc_url( trailingslashit( home_url() ) )
+	);
+
+	$genesis_404_content = sprintf( '<p>%s</p>', $genesis_404_content );
+
+	/**
+	 * The 404 content (wrapped in paragraph tags).
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param string $genesis_404_content The content.
+	 */
+	$genesis_404_content = apply_filters( 'genesis_404_entry_content', $genesis_404_content );
+
+	genesis_markup(
+		[
+			'open'    => '<div %s>',
+			'close'   => '</div>',
+			'content' => $genesis_404_content,
+			'context' => 'entry-content',
+		]
+	);
+}
+
+/**
+ * Output the chosen block area.
+ */
+function thinkery_404_block_area() {
+	if ( ! class_exists( '\Thinkery\Block_Area' ) ) {
+		return;
+	}
+
+	$block_area = get_theme_mod( '404_page_block_area', true );
+	\Thinkery\block_area()->show( $block_area );
+}
+
+genesis();

--- a/wp-content/themes/thinkery/lib/customize.php
+++ b/wp-content/themes/thinkery/lib/customize.php
@@ -111,6 +111,42 @@ function genesis_sample_customizer_register( $wp_customize ) {
 		]
 	);
 
+	/**
+	 * Add options to customize the 404 Page (Block area selector)
+	 *
+	 */
+	$wp_customize->add_setting(
+		'404_page_block_area' , array(
+			'transport' => 'refresh',
+		)
+	);
+	$wp_customize->add_section( '404-page',
+		array(
+			'title' => esc_html_x( '404 Page', 'customizer section title', 'thinkery' ),
+		)
+	);
+	// Get Block Area Posts to populate select option
+	$args = [
+		'numberposts' => '-1',
+		'post_type' => 'block_area',
+	];
+	$block_area_list = get_posts( $args );
+	$block_areas = [];
+	foreach( $block_area_list as $block_area ) {
+		$key = $block_area->post_name;
+		$block_areas[$block_area->ID] = $key;
+	}
+	$wp_customize->add_control(
+		new WP_Customize_Control(
+			$wp_customize, '404_page_block_area', array(
+				'section'       => '404-page',
+				'label'         => esc_html__( '404 Page Block Area', 'thinkery' ),
+				'description'   => esc_html__( 'Select the block area to show on the 404 page.', 'thinkery' ),
+				'type'           => 'select',
+				'choices'        => $block_areas,
+			)
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
## JIRA Ticket

[THNK-51](https://wpengine.atlassian.net/browse/THNK-51)

## Description

A few sentences describing the overall goals of the pull request's commits.

Setup 404 page customizer option to load chosen block areas. Block area can be designed + assigned to replace default 404 page content.

## Impacted Areas in Application

List general components of the site that this PR will affect:

* 404 page
* customizer

## Deploy Notes

Notes regarding deployment the contained body of work.
If you need to change something in WordPress after deploying, make the necessary steps crystal clear.

## Steps to Test or Reproduce

1. Pull down branch
2. Visit Block areas CPT & create a Block area for 404 page
3. Visit customizer > 404 > 404 Page Block Area + select your block area
4. Visit a 404 page, see your block area.

## Random GIF

Include one random GIF to "pay" your reviewers in humor.

![Thanks for reviewing my code!](https://media.giphy.com/media/VwoJkTfZAUBSU/giphy.gif)
