### PR TITLE
Event calendar tooltip template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 Thumbs.db
 
 .htaccess
+docker-compose.yml
 
 # Version Control files
 *.bak

--- a/wp-content/themes/thinkery/style.css
+++ b/wp-content/themes/thinkery/style.css
@@ -5,7 +5,7 @@ Description: This is a child theme based on the Genesis Sample theme created for
 Author: StudioPress
 Author URI: https://www.studiopress.com/
 
-Version: 3.1.0
+Version: 3.1.1
 
 Tags: accessibility-ready, block-styles, custom-colors, custom-logo, custom-menu, editor-style, featured-images, footer-widgets, full-width-template, left-sidebar, one-column, right-sidebar, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready, two-columns, wide-blocks
 
@@ -1995,6 +1995,13 @@ a.tribe-event-url:hover {
 	right: 0;
 	width: 22px;
 	margin: 0 auto;
+}
+.tribe-events-tooltip .tribe-event-link p {
+	margin-bottom: 0;
+}
+.tribe-events-tooltip .tribe-event-link a {
+	padding: 8px 16px;
+	border-radius: 99em;
 }
 span.tribe-events-arrow::after {
 	content: '';

--- a/wp-content/themes/thinkery/tribe-events/month/tooltip.php
+++ b/wp-content/themes/thinkery/tribe-events/month/tooltip.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Please see single-event.php in this directory for detailed instructions
+ * on how to use and modify these templates.
+ *
+ * Overrides the core Tooltip template from the-events-calendar
+ *
+ * @version 4.6.21
+ * @package thinkery
+ */
+
+?>
+
+<script type="text/html" id="tribe_tmpl_tooltip">
+	<div id="tribe-events-tooltip-[[=eventId]]" class="tribe-events-tooltip">
+		<h3 class="entry-title summary"><a href="[[=permalink]]">[[=raw title]]<\/a><\/h3>
+
+		<div class="tribe-events-event-body">
+			<div class="tribe-event-duration">
+				<abbr class="tribe-events-abbr tribe-event-date-start">[[=dateDisplay]] <\/abbr>
+			<\/div>
+			[[ if(imageTooltipSrc.length) { ]]
+				<div class="tribe-events-event-thumb">
+					<img src="[[=imageTooltipSrc]]" alt="[[=title]]" \/>
+				<\/div>
+			[[ } ]]
+			[[ if(excerpt.length) { ]]
+				<div class="tribe-event-description">
+					[[=raw excerpt]]
+
+				<\/div>
+			[[ } ]]
+			<div class="tribe-event-link">
+				<p><a href="[[=permalink]]">Learn More<\/a><\/p>
+			<\/div>
+			<span class="tribe-events-arrow"><\/span>
+		<\/div>
+	<\/div>
+</script>
+
+<script type="text/html" id="tribe_tmpl_tooltip_featured">
+	<div id="tribe-events-tooltip-[[=eventId]]" class="tribe-events-tooltip tribe-event-featured">
+		[[ if(imageTooltipSrc.length) { ]]
+			<div class="tribe-events-event-thumb">
+				<img src="[[=imageTooltipSrc]]" alt="[[=title]]" \/>
+			<\/div>
+		[[ } ]]
+
+		<h3 class="entry-title summary"><a href="[[=permalink]]">[[=raw title]]<\/a><\/h3>
+
+		<div class="tribe-events-event-body">
+			<div class="tribe-event-duration">
+				<abbr class="tribe-events-abbr tribe-event-date-start">[[=dateDisplay]] <\/abbr>
+			<\/div>
+
+			[[ if(excerpt.length) { ]]
+			<div class="tribe-event-description">[[=raw excerpt]]<\/div>
+			[[ } ]]
+			<div class="tribe-event-link">
+				<p><a href="[[=permalink]]">Learn More<\/a><\/p>
+			<\/div>
+			<span class="tribe-events-arrow"><\/span>
+		<\/div>
+	<\/div>
+</script>


### PR DESCRIPTION
## Description

Adds links to the calendar tooltip to the event's single view.

## Impacted Areas in Application

* Monthly Calendar view of Events Calendar Pro

## Steps to Test or Reproduce

1. View /calendar/
2. Hover over an event
3. Click on title or "Learn More" to go to individual event page.

## Random GIF

Include one random GIF to "pay" your reviewers in humor.

![Thanks for reviewing my code!](https://media.giphy.com/media/rvjIGIOI9lhsc/giphy.gif)
