### PR TITLE
Fix tooltip spacing - prevent overlap when description is not provided

### DIFF
--- a/wp-content/themes/thinkery/style.css
+++ b/wp-content/themes/thinkery/style.css
@@ -2347,6 +2347,16 @@ ul.tribe-events-sub-nav li.tribe-events-nav-previous {
 	padding: 10px 16px 20px;
 }
 
+.tribe-events-tooltip .tribe-event-duration {
+	padding-bottom: 10px;
+}
+.tribe-events-tooltip .tribe-event-description p {
+	margin-bottom: 0;
+}
+.tribe-events-tooltip .tribe-event-link {
+	padding-top: 30px;
+}
+
 #tribe-events .tribe-events-button, .tribe-events-button {
 	background-color: #c6101c;
 	border-radius: 0;


### PR DESCRIPTION
Fixes calendar tool tip spacing bug when no description is provided

## Random GIF

Include one random GIF to "pay" your reviewers in humor.

![Thanks for reviewing my code!](https://media.giphy.com/media/eHEmsqSW9B53K65dnS/giphy-downsized.gif)
